### PR TITLE
Reset "Smartsheet-Change-Agent" header before each call

### DIFF
--- a/Smartsheet.Net.Standard/Http/SmartsheetHttpClient.cs
+++ b/Smartsheet.Net.Standard/Http/SmartsheetHttpClient.cs
@@ -96,6 +96,7 @@ namespace Smartsheet.NET.Standard.Http
             //this.ValidateRequestInjectedType(typeof(T));
 
             this._HttpClient.DefaultRequestHeaders.Remove("Authorization");
+            this._HttpClient.DefaultRequestHeaders.Remove("Smartsheet-Change-Agent");
 
             if (accessToken != null)
             {


### PR DESCRIPTION
If we don't remove the header, it will be duplicated each time. If you make a large number of consecutive calls, say 300, you will end up passing the change agent value dupliated 300 times in the request and eventually overrun the buffer, which will return a 400 Bad Request.