### PR TITLE
Fix cell linking: 'strict' flag must be removed

### DIFF
--- a/Smartsheet.Net.Standard/Entities/Row.cs
+++ b/Smartsheet.Net.Standard/Entities/Row.cs
@@ -42,6 +42,11 @@ namespace Smartsheet.NET.Standard.Entities
 
 			for (var i = 0; i < this.Cells.Count; i++)
 			{
+			    if (this.Cells[i].LinkInFromCell != null)
+			    {
+			        strict = null;
+                }
+
 				if (this.Cells[i].Value != null || this.Cells[i].Formula != null || this.Cells[i].LinkInFromCell != null)
 				{
 					buildCells.Add(this.Cells[i].Build(strict));


### PR DESCRIPTION
When adding new cell links, the 'strict' flag must not be present on the cell object. Values of both 'true' and 'false' will cause the API call the fail and the error message does not correctly reflect the issue. This will detect cell links objects and force the 'strict' flag to be removed.