### PR TITLE
Cleanup namespaces, using statements, and interface usage

### DIFF
--- a/Smartsheet.Net.Standard/Configuration/ApplicationSettings.cs
+++ b/Smartsheet.Net.Standard/Configuration/ApplicationSettings.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-namespace Smartsheet.NET.Standard.Configuration
+namespace Smartsheet.Net.Standard.Configuration
 {
 	public class ApplicationSettings
 	{

--- a/Smartsheet.Net.Standard/Configuration/SmartsheetConfiguration.cs
+++ b/Smartsheet.Net.Standard/Configuration/SmartsheetConfiguration.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-namespace Smartsheet.NET.Standard.Configuration
+namespace Smartsheet.Net.Standard.Configuration
 {
 	public class SmartsheetConfiguration
 	{

--- a/Smartsheet.Net.Standard/Configuration/SmartsheetCredentials.cs
+++ b/Smartsheet.Net.Standard/Configuration/SmartsheetCredentials.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-namespace Smartsheet.NET.Standard.Configuration
+namespace Smartsheet.Net.Standard.Configuration
 {
 	public class SmartsheetCredentials
 	{

--- a/Smartsheet.Net.Standard/Definitions/ColumnType.cs
+++ b/Smartsheet.Net.Standard/Definitions/ColumnType.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using System.Text;
 
-namespace Smartsheet.NET.Standard.Definitions
+namespace Smartsheet.Net.Standard.Definitions
 {
     public enum ColumnType
     {

--- a/Smartsheet.Net.Standard/Definitions/DestinationType.cs
+++ b/Smartsheet.Net.Standard/Definitions/DestinationType.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-namespace Smartsheet.NET.Standard.Definitions
+namespace Smartsheet.Net.Standard.Definitions
 {
 	public enum DestinationType
 	{

--- a/Smartsheet.Net.Standard/Definitions/SheetCopyInclusion.cs
+++ b/Smartsheet.Net.Standard/Definitions/SheetCopyInclusion.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-namespace Smartsheet.NET.Standard.Definitions
+namespace Smartsheet.Net.Standard.Definitions
 {
 	public enum SheetCopyInclusion
 	{

--- a/Smartsheet.Net.Standard/Definitions/Symbol.cs
+++ b/Smartsheet.Net.Standard/Definitions/Symbol.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using System.Text;
 
-namespace Smartsheet.NET.Standard.Definitions
+namespace Smartsheet.Net.Standard.Definitions
 {
     public enum Symbol
     {

--- a/Smartsheet.Net.Standard/Definitions/SystemColumnType.cs
+++ b/Smartsheet.Net.Standard/Definitions/SystemColumnType.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using System.Text;
 
-namespace Smartsheet.NET.Standard.Definitions
+namespace Smartsheet.Net.Standard.Definitions
 {
     public enum SystemColumnType
     {

--- a/Smartsheet.Net.Standard/Entities/AlternateEmail.cs
+++ b/Smartsheet.Net.Standard/Entities/AlternateEmail.cs
@@ -1,6 +1,6 @@
 ﻿using Smartsheet.Net.Standard.Interfaces;
 
-namespace Smartsheet.NET.Standard.Entities
+namespace Smartsheet.Net.Standard.Entities
 {
     public class AlternateEmail : ISmartsheetObject
     {

--- a/Smartsheet.Net.Standard/Entities/Attachment.cs
+++ b/Smartsheet.Net.Standard/Entities/Attachment.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using Smartsheet.Net.Standard.Interfaces;
 
-namespace Smartsheet.NET.Standard.Entities
+namespace Smartsheet.Net.Standard.Entities
 {
     public class Attachment : ISmartsheetObject
     {

--- a/Smartsheet.Net.Standard/Entities/AutoNumberFormat.cs
+++ b/Smartsheet.Net.Standard/Entities/AutoNumberFormat.cs
@@ -1,6 +1,6 @@
 ﻿using Smartsheet.Net.Standard.Interfaces;
 
-namespace Smartsheet.NET.Standard.Entities
+namespace Smartsheet.Net.Standard.Entities
 {
     public class AutoNumberFormat : ISmartsheetObject
     {

--- a/Smartsheet.Net.Standard/Entities/Cell.cs
+++ b/Smartsheet.Net.Standard/Entities/Cell.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using Newtonsoft.Json;
 using Smartsheet.Net.Standard.Interfaces;
 
-namespace Smartsheet.NET.Standard.Entities
+namespace Smartsheet.Net.Standard.Entities
 { 
     public enum CellType
     {

--- a/Smartsheet.Net.Standard/Entities/CellLink.cs
+++ b/Smartsheet.Net.Standard/Entities/CellLink.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-namespace Smartsheet.NET.Standard.Entities
+namespace Smartsheet.Net.Standard.Entities
 {
     public class CellLink
     {

--- a/Smartsheet.Net.Standard/Entities/Column.cs
+++ b/Smartsheet.Net.Standard/Entities/Column.cs
@@ -1,9 +1,9 @@
 ﻿using System.Collections.Generic;
-using Smartsheet.NET.Standard.Definitions;
+using Smartsheet.Net.Standard.Definitions;
 using System;
 using Smartsheet.Net.Standard.Interfaces;
 
-namespace Smartsheet.NET.Standard.Entities
+namespace Smartsheet.Net.Standard.Entities
 {
 	public class Column : ISmartsheetObject
 	{

--- a/Smartsheet.Net.Standard/Entities/Comment.cs
+++ b/Smartsheet.Net.Standard/Entities/Comment.cs
@@ -1,6 +1,6 @@
 ﻿using Smartsheet.Net.Standard.Interfaces;
 
-namespace Smartsheet.NET.Standard.Entities
+namespace Smartsheet.Net.Standard.Entities
 {
     public class Comment : ISmartsheetObject
     {

--- a/Smartsheet.Net.Standard/Entities/ContactOptions.cs
+++ b/Smartsheet.Net.Standard/Entities/ContactOptions.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace Smartsheet.NET.Standard.Entities
+﻿namespace Smartsheet.Net.Standard.Entities
 {
 	public class ContactOptions
 	{

--- a/Smartsheet.Net.Standard/Entities/ContainerDestination.cs
+++ b/Smartsheet.Net.Standard/Entities/ContainerDestination.cs
@@ -1,6 +1,6 @@
 ﻿using Smartsheet.Net.Standard.Interfaces;
 
-namespace Smartsheet.NET.Standard.Entities
+namespace Smartsheet.Net.Standard.Entities
 {
 	public class ContainerDestination : ISmartsheetObject
 	{

--- a/Smartsheet.Net.Standard/Entities/Criteria.cs
+++ b/Smartsheet.Net.Standard/Entities/Criteria.cs
@@ -1,6 +1,6 @@
 ﻿using Smartsheet.Net.Standard.Interfaces;
 
-namespace Smartsheet.NET.Standard.Entities
+namespace Smartsheet.Net.Standard.Entities
 {
     public class Criteria : ISmartsheetObject
     {

--- a/Smartsheet.Net.Standard/Entities/Discussion.cs
+++ b/Smartsheet.Net.Standard/Entities/Discussion.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using Smartsheet.Net.Standard.Interfaces;
 
-namespace Smartsheet.NET.Standard.Entities
+namespace Smartsheet.Net.Standard.Entities
 {
     public class Discussion : ISmartsheetObject
     {

--- a/Smartsheet.Net.Standard/Entities/Email.cs
+++ b/Smartsheet.Net.Standard/Entities/Email.cs
@@ -1,12 +1,9 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Collections.Generic;
+using Smartsheet.Net.Standard.Interfaces;
 
-namespace Smartsheet.NET.Standard.Entities
+namespace Smartsheet.Net.Standard.Entities
 {
-    public class Email : SmartsheetObject
+    public class Email : ISmartsheetObject
     {
         public Email()
         {

--- a/Smartsheet.Net.Standard/Entities/Filter.cs
+++ b/Smartsheet.Net.Standard/Entities/Filter.cs
@@ -1,7 +1,7 @@
 ﻿using System.Collections.Generic;
 using Smartsheet.Net.Standard.Interfaces;
 
-namespace Smartsheet.NET.Standard.Entities
+namespace Smartsheet.Net.Standard.Entities
 {
     public class Filter : ISmartsheetObject
     {

--- a/Smartsheet.Net.Standard/Entities/Folder.cs
+++ b/Smartsheet.Net.Standard/Entities/Folder.cs
@@ -1,7 +1,7 @@
 ﻿using System.Collections.Generic;
 using Smartsheet.Net.Standard.Interfaces;
 
-namespace Smartsheet.NET.Standard.Entities
+namespace Smartsheet.Net.Standard.Entities
 {
     public class Folder : ISmartsheetObject
     {

--- a/Smartsheet.Net.Standard/Entities/Group.cs
+++ b/Smartsheet.Net.Standard/Entities/Group.cs
@@ -1,10 +1,10 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using Smartsheet.Net.Standard.Interfaces;
 
-namespace Smartsheet.NET.Standard.Entities
+namespace Smartsheet.Net.Standard.Entities
 {
-    public class Group : SmartsheetObject
+    public class Group : ISmartsheetObject
     {
        
         public Group()

--- a/Smartsheet.Net.Standard/Entities/GroupMember.cs
+++ b/Smartsheet.Net.Standard/Entities/GroupMember.cs
@@ -1,10 +1,8 @@
-using System;
-using System.Collections.Generic;
-using Smartsheet.Net.Standard.Interfaces;
+﻿using Smartsheet.Net.Standard.Interfaces;
 
-namespace Smartsheet.NET.Standard.Entities
+namespace Smartsheet.Net.Standard.Entities
 {
-    public class GroupMember : SmartsheetObject
+    public class GroupMember : ISmartsheetObject
     {
         public GroupMember()
         {

--- a/Smartsheet.Net.Standard/Entities/Home.cs
+++ b/Smartsheet.Net.Standard/Entities/Home.cs
@@ -1,7 +1,7 @@
 ﻿using System.Collections.Generic;
 using Smartsheet.Net.Standard.Interfaces;
 
-namespace Smartsheet.NET.Standard.Entities
+namespace Smartsheet.Net.Standard.Entities
 {
     public class Home : ISmartsheetObject
     {

--- a/Smartsheet.Net.Standard/Entities/Hyperlink.cs
+++ b/Smartsheet.Net.Standard/Entities/Hyperlink.cs
@@ -1,6 +1,6 @@
 ﻿using Smartsheet.Net.Standard.Interfaces;
 
-namespace Smartsheet.NET.Standard.Entities
+namespace Smartsheet.Net.Standard.Entities
 {
     public class Hyperlink : ISmartsheetObject
     {

--- a/Smartsheet.Net.Standard/Entities/MultiRowEmail.cs
+++ b/Smartsheet.Net.Standard/Entities/MultiRowEmail.cs
@@ -1,10 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Collections.Generic;
 
-namespace Smartsheet.NET.Standard.Entities
+namespace Smartsheet.Net.Standard.Entities
 {
     public class MultiRowEmail : RowEmail
     {

--- a/Smartsheet.Net.Standard/Entities/Recipient.cs
+++ b/Smartsheet.Net.Standard/Entities/Recipient.cs
@@ -1,12 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using Smartsheet.Net.Standard.Interfaces;
 
-namespace Smartsheet.NET.Standard.Entities
+namespace Smartsheet.Net.Standard.Entities
 {
-    public class Recipient : SmartsheetObject
+    public class Recipient : ISmartsheetObject
     {
         public Recipient()
         {

--- a/Smartsheet.Net.Standard/Entities/Report.cs
+++ b/Smartsheet.Net.Standard/Entities/Report.cs
@@ -1,6 +1,6 @@
 ﻿using System.Collections.Generic;
 
-namespace Smartsheet.NET.Standard.Entities
+namespace Smartsheet.Net.Standard.Entities
 {
     public class Report : Sheet
     {

--- a/Smartsheet.Net.Standard/Entities/Row.cs
+++ b/Smartsheet.Net.Standard/Entities/Row.cs
@@ -1,10 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using Smartsheet.Net.Standard.Interfaces;
 
-namespace Smartsheet.NET.Standard.Entities
+namespace Smartsheet.Net.Standard.Entities
 {
-	public class Row : SmartsheetObject
+	public class Row : ISmartsheetObject
 	{
 		public Row()
 		{

--- a/Smartsheet.Net.Standard/Entities/RowEmail.cs
+++ b/Smartsheet.Net.Standard/Entities/RowEmail.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace Smartsheet.NET.Standard.Entities
+namespace Smartsheet.Net.Standard.Entities
 {
     public class RowEmail : Email
     {

--- a/Smartsheet.Net.Standard/Entities/Sheet.cs
+++ b/Smartsheet.Net.Standard/Entities/Sheet.cs
@@ -1,11 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using Smartsheet.NET.Standard.Http;
+using Smartsheet.Net.Standard.Http;
 using System.Threading.Tasks;
 using Smartsheet.Net.Standard.Responses;
 
-namespace Smartsheet.NET.Standard.Entities
+namespace Smartsheet.Net.Standard.Entities
 {
 	public class Sheet : SmartsheetObject
 	{

--- a/Smartsheet.Net.Standard/Entities/Sight.cs
+++ b/Smartsheet.Net.Standard/Entities/Sight.cs
@@ -1,9 +1,9 @@
 ﻿using System;
-using Smartsheet.NET.Standard.Entities;
+using Smartsheet.Net.Standard.Interfaces;
 
-namespace Smartsheet.NET.Standard.Entities
+namespace Smartsheet.Net.Standard.Entities
 {
-    public class Sight : SmartsheetObject
+    public class Sight : ISmartsheetObject
     {
         public Sight()
         {

--- a/Smartsheet.Net.Standard/Entities/SmartsheetObject.cs
+++ b/Smartsheet.Net.Standard/Entities/SmartsheetObject.cs
@@ -1,4 +1,4 @@
-﻿using Smartsheet.NET.Standard.Http;
+﻿using Smartsheet.Net.Standard.Http;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -6,7 +6,7 @@ using System.Text;
 using System.Threading.Tasks;
 using Smartsheet.Net.Standard.Interfaces;
 
-namespace Smartsheet.NET.Standard.Entities
+namespace Smartsheet.Net.Standard.Entities
 {
     public class SmartsheetObject : ISmartsheetObject
     {

--- a/Smartsheet.Net.Standard/Entities/Template.cs
+++ b/Smartsheet.Net.Standard/Entities/Template.cs
@@ -1,7 +1,7 @@
 ﻿using System.Collections.Generic;
 using Smartsheet.Net.Standard.Interfaces;
 
-namespace Smartsheet.NET.Standard.Entities
+namespace Smartsheet.Net.Standard.Entities
 {
     public class Template : ISmartsheetObject
     {

--- a/Smartsheet.Net.Standard/Entities/Token.cs
+++ b/Smartsheet.Net.Standard/Entities/Token.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using Smartsheet.NET.Standard.Interfaces;
+using Smartsheet.Net.Standard.Interfaces;
 
 namespace Smartsheet.Net.Standard.Entities
 {

--- a/Smartsheet.Net.Standard/Entities/UpdateRequest.cs
+++ b/Smartsheet.Net.Standard/Entities/UpdateRequest.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace Smartsheet.NET.Standard.Entities
+namespace Smartsheet.Net.Standard.Entities
 {
     public class UpdateRequest : MultiRowEmail
     {

--- a/Smartsheet.Net.Standard/Entities/User.cs
+++ b/Smartsheet.Net.Standard/Entities/User.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using Smartsheet.Net.Standard.Interfaces;
 
-namespace Smartsheet.NET.Standard.Entities
+namespace Smartsheet.Net.Standard.Entities
 {
     public class User : ISmartsheetObject
     {

--- a/Smartsheet.Net.Standard/Entities/UserSettings.cs
+++ b/Smartsheet.Net.Standard/Entities/UserSettings.cs
@@ -1,6 +1,6 @@
 ﻿using Smartsheet.Net.Standard.Interfaces;
 
-namespace Smartsheet.NET.Standard.Entities
+namespace Smartsheet.Net.Standard.Entities
 {
     public class UserSettings : ISmartsheetObject
     {

--- a/Smartsheet.Net.Standard/Entities/Webhook.cs
+++ b/Smartsheet.Net.Standard/Entities/Webhook.cs
@@ -1,8 +1,5 @@
 ﻿using System;
-using System.Collections;
 using System.Collections.Generic;
-using Smartsheet.NET.Standard;
-using Smartsheet.NET.Standard.Entities;
 
 namespace Smartsheet.Net.Standard.Entities
 {

--- a/Smartsheet.Net.Standard/Entities/WebhookCallback.cs
+++ b/Smartsheet.Net.Standard/Entities/WebhookCallback.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 
-namespace Smartsheet.NET.Standard.Entities
+namespace Smartsheet.Net.Standard.Entities
 {
 	public class WebhookCallback
 	{

--- a/Smartsheet.Net.Standard/Entities/WebhookCallbackEvent.cs
+++ b/Smartsheet.Net.Standard/Entities/WebhookCallbackEvent.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-namespace Smartsheet.NET.Standard.Entities
+namespace Smartsheet.Net.Standard.Entities
 {
 	public class WebhookCallbackEvent
 	{

--- a/Smartsheet.Net.Standard/Entities/WebhookStats.cs
+++ b/Smartsheet.Net.Standard/Entities/WebhookStats.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace Smartsheet.NET.Standard.Entities
+namespace Smartsheet.Net.Standard.Entities
 {
 	public class WebhookStats
 	{

--- a/Smartsheet.Net.Standard/Entities/WebhookVerification.cs
+++ b/Smartsheet.Net.Standard/Entities/WebhookVerification.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-namespace Smartsheet.NET.Standard.Entities
+namespace Smartsheet.Net.Standard.Entities
 {
 	public class WebhookVerification
 	{

--- a/Smartsheet.Net.Standard/Entities/Workspace.cs
+++ b/Smartsheet.Net.Standard/Entities/Workspace.cs
@@ -1,7 +1,7 @@
 ﻿using System.Collections.Generic;
 using Smartsheet.Net.Standard.Interfaces;
 
-namespace Smartsheet.NET.Standard.Entities
+namespace Smartsheet.Net.Standard.Entities
 {
     public class Workspace : ISmartsheetObject
     {

--- a/Smartsheet.Net.Standard/Hash/SHA.cs
+++ b/Smartsheet.Net.Standard/Hash/SHA.cs
@@ -3,7 +3,7 @@ using System.Security.Cryptography;
 using System.Text;
 using System.Text.Encodings;
 
-namespace Smartsheet.NET.Standard.Hash
+namespace Smartsheet.Net.Standard.Hash
 {
 	public static class SHA
 	{

--- a/Smartsheet.Net.Standard/Http/HttpVerb.cs
+++ b/Smartsheet.Net.Standard/Http/HttpVerb.cs
@@ -1,4 +1,4 @@
-﻿namespace Smartsheet.NET.Standard.Http
+﻿namespace Smartsheet.Net.Standard.Http
 {
     public enum HttpVerb
     {

--- a/Smartsheet.Net.Standard/Http/SmartsheetHttpClient.cs
+++ b/Smartsheet.Net.Standard/Http/SmartsheetHttpClient.cs
@@ -1,7 +1,7 @@
 ﻿using Newtonsoft.Json;
-using Smartsheet.NET.Standard.Definitions;
-using Smartsheet.NET.Standard.Entities;
-using Smartsheet.NET.Standard.Interfaces;
+using Smartsheet.Net.Standard.Definitions;
+using Smartsheet.Net.Standard.Entities;
+using Smartsheet.Net.Standard.Interfaces;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -9,22 +9,19 @@ using System.Net;
 using System.Net.Http;
 using System.Reflection;
 using Newtonsoft.Json.Serialization;
-using Smartsheet.NET.Standard.Responses;
+using Smartsheet.Net.Standard.Responses;
 using System.Threading.Tasks;
 using System.Threading;
 using System.Collections;
 using Microsoft.AspNetCore.WebUtilities;
 using System.Net.Http.Headers;
 using Microsoft.Extensions.Options;
-using Smartsheet.NET.Standard.Configuration;
+using Smartsheet.Net.Standard.Configuration;
 using System.IO;
 using Microsoft.AspNetCore.Http;
-using Smartsheet.Net.Standard.Interfaces;
-using Smartsheet.Net.Standard.Responses;
-using Smartsheet.Net.Standard.Entities;
-using Smartsheet.NET.Standard.Hash;
+using Smartsheet.Net.Standard.Hash;
 
-namespace Smartsheet.NET.Standard.Http
+namespace Smartsheet.Net.Standard.Http
 {
     public class SmartsheetHttpClient : ISmartsheetHttpClient
     {

--- a/Smartsheet.Net.Standard/Interfaces/ISmartsheetHttpClient.cs
+++ b/Smartsheet.Net.Standard/Interfaces/ISmartsheetHttpClient.cs
@@ -1,18 +1,14 @@
-﻿using Smartsheet.NET.Standard.Http;
+﻿using Smartsheet.Net.Standard.Http;
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using Smartsheet.NET.Standard.Entities;
+using Smartsheet.Net.Standard.Entities;
 using System.Net.Http;
-using Smartsheet.NET.Standard.Interfaces;
-using Smartsheet.NET.Standard.Definitions;
-using Smartsheet.NET.Standard.Responses;
+using Smartsheet.Net.Standard.Definitions;
+using Smartsheet.Net.Standard.Responses;
 using System.IO;
 using Microsoft.AspNetCore.Http;
-using Smartsheet.Net.Standard;
-using Smartsheet.Net.Standard.Interfaces;
-using Smartsheet.Net.Standard.Entities;
 
-namespace Smartsheet.NET.Standard.Interfaces
+namespace Smartsheet.Net.Standard.Interfaces
 {
 	public interface ISmartsheetHttpClient
 	{

--- a/Smartsheet.Net.Standard/Interfaces/ISmartsheetObject.cs
+++ b/Smartsheet.Net.Standard/Interfaces/ISmartsheetObject.cs
@@ -1,7 +1,4 @@
-﻿using Smartsheet.NET.Standard.Http;
-using Smartsheet.NET.Standard.Interfaces;
-
-namespace Smartsheet.Net.Standard.Interfaces
+﻿namespace Smartsheet.Net.Standard.Interfaces
 {
     public interface ISmartsheetObject : ISmartsheetResult
     {

--- a/Smartsheet.Net.Standard/Interfaces/ISmartsheetResult.cs
+++ b/Smartsheet.Net.Standard/Interfaces/ISmartsheetResult.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace Smartsheet.NET.Standard.Interfaces
+namespace Smartsheet.Net.Standard.Interfaces
 {
     public interface ISmartsheetResult
     {

--- a/Smartsheet.Net.Standard/Responses/BulkItemFailureResponse.cs
+++ b/Smartsheet.Net.Standard/Responses/BulkItemFailureResponse.cs
@@ -1,4 +1,4 @@
-﻿using Smartsheet.NET.Standard.Interfaces;
+﻿using Smartsheet.Net.Standard.Interfaces;
 
 namespace Smartsheet.Net.Standard.Responses
 {

--- a/Smartsheet.Net.Standard/Responses/ContainerDestinationObject.cs
+++ b/Smartsheet.Net.Standard/Responses/ContainerDestinationObject.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using Smartsheet.NET.Standard.Interfaces;
+using Smartsheet.Net.Standard.Interfaces;
 
 namespace Smartsheet.Net.Standard.Responses
 {

--- a/Smartsheet.Net.Standard/Responses/CopyOrMoveRowDestination.cs
+++ b/Smartsheet.Net.Standard/Responses/CopyOrMoveRowDestination.cs
@@ -1,7 +1,7 @@
 ﻿using System;
-using Smartsheet.NET.Standard.Interfaces;
+using Smartsheet.Net.Standard.Interfaces;
 
-namespace Smartsheet.NET.Standard.Responses
+namespace Smartsheet.Net.Standard.Responses
 {
     public class CopyOrMoveRowDestination : ISmartsheetResult
     {

--- a/Smartsheet.Net.Standard/Responses/CopyOrMoveRowDirective.cs
+++ b/Smartsheet.Net.Standard/Responses/CopyOrMoveRowDirective.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 
-namespace Smartsheet.NET.Standard.Responses
+namespace Smartsheet.Net.Standard.Responses
 {
     public class CopyOrMoveRowDirective
     {

--- a/Smartsheet.Net.Standard/Responses/CopyOrMoveRowResult.cs
+++ b/Smartsheet.Net.Standard/Responses/CopyOrMoveRowResult.cs
@@ -1,8 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
-using Smartsheet.NET.Standard.Interfaces;
+using Smartsheet.Net.Standard.Interfaces;
 
-namespace Smartsheet.NET.Standard.Responses
+namespace Smartsheet.Net.Standard.Responses
 {
     public class CopyOrMoveRowResult : ISmartsheetResult
     {

--- a/Smartsheet.Net.Standard/Responses/ErrorResponse.cs
+++ b/Smartsheet.Net.Standard/Responses/ErrorResponse.cs
@@ -1,4 +1,4 @@
-﻿using Smartsheet.NET.Standard.Interfaces;
+﻿using Smartsheet.Net.Standard.Interfaces;
 
 namespace Smartsheet.Net.Standard.Responses
 {

--- a/Smartsheet.Net.Standard/Responses/IndexResultResponse.cs
+++ b/Smartsheet.Net.Standard/Responses/IndexResultResponse.cs
@@ -1,11 +1,11 @@
-﻿using Smartsheet.NET.Standard.Interfaces;
+﻿using Smartsheet.Net.Standard.Interfaces;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace Smartsheet.NET.Standard.Responses
+namespace Smartsheet.Net.Standard.Responses
 {
 	public class IndexResultResponse<T> : ISmartsheetResult
 	{

--- a/Smartsheet.Net.Standard/Responses/ResultResponse.cs
+++ b/Smartsheet.Net.Standard/Responses/ResultResponse.cs
@@ -1,4 +1,4 @@
-﻿using Smartsheet.NET.Standard.Interfaces;
+﻿using Smartsheet.Net.Standard.Interfaces;
 using System.Collections.Generic;
 
 namespace Smartsheet.Net.Standard.Responses

--- a/Smartsheet.Net.Standard/Responses/RowMapping.cs
+++ b/Smartsheet.Net.Standard/Responses/RowMapping.cs
@@ -1,6 +1,6 @@
-﻿using Smartsheet.NET.Standard.Interfaces;
+﻿using Smartsheet.Net.Standard.Interfaces;
 
-namespace Smartsheet.NET.Standard.Responses
+namespace Smartsheet.Net.Standard.Responses
 {
     public class RowMapping : ISmartsheetResult
     {


### PR DESCRIPTION
- Be conistent in using Smartsheet.Net.Standard over Smartsheet.NET.Standard
- Cleanup duplicate and unneeded using statements
- Use ISmartsheetObject over Smartsheet object where applicable