### PR TITLE
Add loadAll parameter to Get Workspace calls where valid

### DIFF
--- a/Smartsheet.Net.Standard/Http/SmartsheetHttpClient.cs
+++ b/Smartsheet.Net.Standard/Http/SmartsheetHttpClient.cs
@@ -429,7 +429,7 @@ namespace Smartsheet.Net.Standard.Http
                 throw new Exception("Workspace ID cannot be null");
             }
 
-			var response = await this.ExecuteRequest<Workspace, Workspace>(HttpVerb.GET, string.Format("workspaces/{0}?loadAll={1}", workspaceId, loadAll ? "true" : "false"), null, accessToken: accessToken);
+            var response = await this.ExecuteRequest<Workspace, Workspace>(HttpVerb.GET, string.Format("workspaces/{0}?loadAll={1}", workspaceId, loadAll ? "true" : "false"), null, accessToken: accessToken);
 
             return response;
         }
@@ -703,7 +703,7 @@ namespace Smartsheet.Net.Standard.Http
                 throw new Exception("Workspace ID cannot be null");
             }
 
-			var response = await this.ExecuteRequest<Workspace, Workspace>(HttpVerb.GET, string.Format("workspaces/{0}?loadAll={1}", workspaceId, loadAll ? "true" : "false"), null, accessToken: accessToken);
+            var response = await this.ExecuteRequest<Workspace, Workspace>(HttpVerb.GET, string.Format("workspaces/{0}?loadAll={1}", workspaceId, loadAll ? "true" : "false"), null, accessToken: accessToken);
 
             return response.Folders;
         }
@@ -750,7 +750,7 @@ namespace Smartsheet.Net.Standard.Http
                 throw new Exception("Workspace ID cannot be null");
             }
 
-			var response = await this.ExecuteRequest<Workspace, Workspace>(HttpVerb.GET, string.Format("workspaces/{0}", workspaceId), null, accessToken: accessToken);
+            var response = await this.ExecuteRequest<Workspace, Workspace>(HttpVerb.GET, string.Format("workspaces/{0}", workspaceId), null, accessToken: accessToken);
 
             return response.Reports;
         }
@@ -773,7 +773,7 @@ namespace Smartsheet.Net.Standard.Http
                 throw new Exception("Workspace ID cannot be null");
             }
 
-			var response = await this.ExecuteRequest<Workspace, Workspace>(HttpVerb.GET, string.Format("workspaces/{0}", workspaceId), null, accessToken: accessToken);
+            var response = await this.ExecuteRequest<Workspace, Workspace>(HttpVerb.GET, string.Format("workspaces/{0}", workspaceId), null, accessToken: accessToken);
 
             return response.Templates;
         }

--- a/Smartsheet.Net.Standard/Http/SmartsheetHttpClient.cs
+++ b/Smartsheet.Net.Standard/Http/SmartsheetHttpClient.cs
@@ -422,14 +422,14 @@ namespace Smartsheet.Net.Standard.Http
             return response.Result;
         }
 
-        public async Task<ISmartsheetObject> GetWorkspaceById(long? workspaceId, string accessToken = null)
+        public async Task<ISmartsheetObject> GetWorkspaceById(long? workspaceId, string accessToken = null, bool loadAll = false)
         {
             if (workspaceId == null)
             {
                 throw new Exception("Workspace ID cannot be null");
             }
 
-            var response = await this.ExecuteRequest<Workspace, Workspace>(HttpVerb.GET, string.Format("workspaces/{0}", workspaceId), null, accessToken: accessToken);
+			var response = await this.ExecuteRequest<Workspace, Workspace>(HttpVerb.GET, string.Format("workspaces/{0}?loadAll={1}", workspaceId, loadAll ? "true" : "false"), null, accessToken: accessToken);
 
             return response;
         }
@@ -696,14 +696,14 @@ namespace Smartsheet.Net.Standard.Http
 
 
         #region Folders
-        public async Task<IEnumerable<Folder>> GetFoldersForWorkspace(long? workspaceId, string accessToken = null)
+        public async Task<IEnumerable<Folder>> GetFoldersForWorkspace(long? workspaceId, string accessToken = null, bool loadAll = false)
         {
             if (workspaceId == null)
             {
                 throw new Exception("Workspace ID cannot be null");
             }
 
-            var response = await this.ExecuteRequest<Workspace, Workspace>(HttpVerb.GET, string.Format("workspaces/{0}", workspaceId), null, accessToken: accessToken);
+			var response = await this.ExecuteRequest<Workspace, Workspace>(HttpVerb.GET, string.Format("workspaces/{0}?loadAll={1}", workspaceId, loadAll ? "true" : "false"), null, accessToken: accessToken);
 
             return response.Folders;
         }
@@ -750,7 +750,7 @@ namespace Smartsheet.Net.Standard.Http
                 throw new Exception("Workspace ID cannot be null");
             }
 
-            var response = await this.ExecuteRequest<Workspace, Workspace>(HttpVerb.GET, string.Format("workspaces/{0}", workspaceId), null, accessToken: accessToken);
+			var response = await this.ExecuteRequest<Workspace, Workspace>(HttpVerb.GET, string.Format("workspaces/{0}", workspaceId), null, accessToken: accessToken);
 
             return response.Reports;
         }
@@ -773,7 +773,7 @@ namespace Smartsheet.Net.Standard.Http
                 throw new Exception("Workspace ID cannot be null");
             }
 
-            var response = await this.ExecuteRequest<Workspace, Workspace>(HttpVerb.GET, string.Format("workspaces/{0}", workspaceId), null, accessToken: accessToken);
+			var response = await this.ExecuteRequest<Workspace, Workspace>(HttpVerb.GET, string.Format("workspaces/{0}", workspaceId), null, accessToken: accessToken);
 
             return response.Templates;
         }

--- a/Smartsheet.Net.Standard/Interfaces/ISmartsheetHttpClient.cs
+++ b/Smartsheet.Net.Standard/Interfaces/ISmartsheetHttpClient.cs
@@ -23,7 +23,7 @@ namespace Smartsheet.Net.Standard.Interfaces
 
 		//	Workspaces
 		Task<ISmartsheetObject> CreateWorkspace(string workspaceName, string accessToken = null);
-		Task<ISmartsheetObject> GetWorkspaceById(long? workspaceId, string accessToken = null);
+		Task<ISmartsheetObject> GetWorkspaceById(long? workspaceId, string accessToken = null, bool loadAll = false);
 
 		//	Sheets
 		Task<Sheet> GetSheetById(long? sheetId, string accessToken = null);
@@ -36,7 +36,7 @@ namespace Smartsheet.Net.Standard.Interfaces
 		Task<IEnumerable<Row>> CreateRows(long? sheetId, IEnumerable<Row> rows, bool? toTop = null, bool? toBottom = null, long? parentId = null, long? siblingId = null, string accessToken = null);
 		Task<CopyOrMoveRowResult> MoveRows(long? sourceSheetId, long? destinationSheetId, IEnumerable<long> rowIds, string accessToken = null);
 		Task<CopyOrMoveRowResult> CopyRows(long? sourceSheetId, long? destinationSheetId, IEnumerable<long> rowIds, string accessToken = null);
-		Task<IEnumerable<Folder>> GetFoldersForWorkspace(long? workspaceId, string accessToken = null);
+		Task<IEnumerable<Folder>> GetFoldersForWorkspace(long? workspaceId, string accessToken = null, bool loadAll = false);
 		Task<Folder> GetFolderById(long? folderId, string accessToken = null);
 
 		//	Reports


### PR DESCRIPTION
GetWorkspaceByID() and GetFoldersForWorkspace() updated to include loadAll parameter, defaulted to false.